### PR TITLE
fix: reuse mod.ssrError

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -31,6 +31,7 @@ export class ModuleNode {
   transformResult: TransformResult | null = null
   ssrTransformResult: TransformResult | null = null
   ssrModule: Record<string, any> | null = null
+  ssrError: Error | null = null
   lastHMRTimestamp = 0
 
   constructor(url: string) {

--- a/packages/vite/src/node/ssr/__tests__/ssrModuleLoader.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrModuleLoader.spec.ts
@@ -17,9 +17,7 @@ test('always throw error when evaluating an wrong SSR module', async () => {
   }
   await viteServer.close()
   expect(expectedErrors).toHaveLength(2)
-  expectedErrors.forEach((error) => {
-    expect(error?.message).toContain(THROW_MESSAGE)
-  })
+  expect(expectedErrors[0]).toBe(expectedErrors[1])
   expect(spy).toBeCalledTimes(2)
   spy.mock.calls.forEach(([info]) => {
     expect(info).toContain('Error when evaluating SSR module')

--- a/packages/vite/src/node/ssr/__tests__/ssrModuleLoader.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrModuleLoader.spec.ts
@@ -18,6 +18,9 @@ test('always throw error when evaluating an wrong SSR module', async () => {
   await viteServer.close()
   expect(expectedErrors).toHaveLength(2)
   expect(expectedErrors[0]).toBe(expectedErrors[1])
+  expectedErrors.forEach((error) => {
+    expect(error?.message).toContain(THROW_MESSAGE)
+  })
   expect(spy).toBeCalledTimes(2)
   spy.mock.calls.forEach(([info]) => {
     expect(info).toContain('Error when evaluating SSR module')

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -77,6 +77,10 @@ async function instantiateModule(
   const { moduleGraph } = server
   const mod = await moduleGraph.ensureEntryFromUrl(url, true)
 
+  if (mod.ssrError) {
+    throw mod.ssrError
+  }
+
   if (mod.ssrModule) {
     return mod.ssrModule
   }
@@ -202,7 +206,7 @@ async function instantiateModule(
       ssrExportAll
     )
   } catch (e) {
-    mod.ssrModule = null
+    mod.ssrError = e
     if (e.stack && fixStacktrace !== false) {
       const stacktrace = ssrRewriteStacktrace(e.stack, moduleGraph)
       rebindErrorStacktrace(e, stacktrace)


### PR DESCRIPTION
### Description

Thank you for the PR to fix https://github.com/vitejs/vite/issues/7030. This addresses my comments in https://github.com/vitejs/vite/pull/7177#issuecomment-1060130012 — by storing the error thrown during module instantiation, we can a) save the effort of reinstantiating it, and b) hew closer to the behaviour of browsers and node.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
